### PR TITLE
Switch from reflect.DeepEqual to bytes.Compare

### DIFF
--- a/deaggregator.go
+++ b/deaggregator.go
@@ -1,8 +1,8 @@
 package deaggregation
 
 import (
+	"bytes"
 	"crypto/md5"
-	"reflect"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/kimutansk/go-kinesis-deaggregation/pb"
@@ -17,7 +17,7 @@ func IsAggregatedRecord(target []byte) bool {
 		return false
 	}
 
-	if !reflect.DeepEqual(magicNumber, target[0:len(magicNumber)]) {
+	if !bytes.Equal(magicNumber, target[0:len(magicNumber)]) {
 		return false
 	}
 
@@ -25,7 +25,7 @@ func IsAggregatedRecord(target []byte) bool {
 	md5Hash.Write(target[len(magicNumber) : length-md5.Size])
 	checkSum := md5Hash.Sum(nil)
 
-	if !reflect.DeepEqual(target[length-md5.Size:length], checkSum) {
+	if !bytes.Equal(target[length-md5.Size:length], checkSum) {
 		return false
 	}
 

--- a/deaggregator_test.go
+++ b/deaggregator_test.go
@@ -54,6 +54,56 @@ func Test_IsAggregatedRecord_JudgeFullAggregatedRecord(t *testing.T) {
 	}
 }
 
+func BenchmarkIsAggregatedNon_Short(b *testing.B) {
+	target := "NotAggregatedRecord"
+	targetByteArray := []byte(target)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		IsAggregatedRecord(targetByteArray)
+	}
+}
+
+func BenchmarkIsAggregatedNon_Long(b *testing.B) {
+	targetByteArray := []byte("some data")
+	for i := 0; i < 1000; i++ {
+		targetByteArray = append(targetByteArray, []byte(", more data")...)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		IsAggregatedRecord(targetByteArray)
+	}
+}
+
+func BenchmarkIsAggregatedMinimum(b *testing.B) {
+	targetRecord := createMinimumAggregateRecordMarshaledBytes()
+	md5Hash := md5.New()
+	md5Hash.Write(targetRecord)
+	checkSum := md5Hash.Sum(nil)
+	targetBytes := append(magicNumber, targetRecord...)
+	targetBytes = append(targetBytes, checkSum...)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		IsAggregatedRecord(targetBytes)
+	}
+}
+
+func BenchmarkIsAggregatedFull(b *testing.B) {
+	targetRecord := createFullAggregateRecordMarshaledBytes()
+	md5Hash := md5.New()
+	md5Hash.Write(targetRecord)
+	checkSum := md5Hash.Sum(nil)
+	targetBytes := append(magicNumber, targetRecord...)
+	targetBytes = append(targetBytes, checkSum...)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		IsAggregatedRecord(targetBytes)
+	}
+}
+
 func Test_ExtractRecordDatas_MinimumAggregatedRecord(t *testing.T) {
 	targetRecord := createMinimumAggregateRecordMarshaledBytes()
 


### PR DESCRIPTION
Results in 4x to 40x speed up checking IsAggregated.

```
benchmark                            old ns/op     new ns/op     delta
BenchmarkIsAggregatedNon_Short-4     167           4.44          -97.34%
BenchmarkIsAggregatedNon_Long-4      165           4.42          -97.32%
BenchmarkIsAggregatedMinimum-4       1642          170           -89.65%
BenchmarkIsAggregatedFull-4          1865          395           -78.82%
```